### PR TITLE
stimulus 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,32 +1017,6 @@
         "picomatch": "^2.2.2"
       }
     },
-    "@stimulus/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@stimulus/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-PVJv7IpuQx0MVPCBblXc6O2zbCmU8dlxXNH4bC9KK6LsvGaE+PCXXrXQfXUwAsse1/CmRu/iQG7Ov58himjiGg==",
-      "requires": {
-        "@stimulus/mutation-observers": "^1.1.1"
-      }
-    },
-    "@stimulus/multimap": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@stimulus/multimap/-/multimap-1.1.1.tgz",
-      "integrity": "sha512-26R1fI3a8uUj0WlMmta4qcfIQGlagegdP4PTz6lz852q/dXlG6r+uPS/bx+H8GtfyS+OOXVr3SkZ0Zg0iRqRfQ=="
-    },
-    "@stimulus/mutation-observers": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@stimulus/mutation-observers/-/mutation-observers-1.1.1.tgz",
-      "integrity": "sha512-/zCnnw1KJlWO2mrx0yxYaRFZWMGnDMdOgSnI4hxDLxdWVuL2HMROU8FpHWVBLjKY3T9A+lGkcrmPGDHF3pfS9w==",
-      "requires": {
-        "@stimulus/multimap": "^1.1.1"
-      }
-    },
-    "@stimulus/webpack-helpers": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@stimulus/webpack-helpers/-/webpack-helpers-1.1.1.tgz",
-      "integrity": "sha512-XOkqSw53N9072FLHvpLM25PIwy+ndkSSbnTtjKuyzsv8K5yfkFB2rv68jU1pzqYa9FZLcvZWP4yazC0V38dx9A=="
-    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -3245,15 +3219,6 @@
         "minimist": "^1.2.5",
         "pkg-conf": "^3.1.0",
         "xdg-basedir": "^4.0.0"
-      }
-    },
-    "stimulus": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stimulus/-/stimulus-1.1.1.tgz",
-      "integrity": "sha512-R0mBqKp48YnRDZOxZ8hiOH4Ilph3Yj78CIFTBkCwyHs4iGCpe7xlEdQ7cjIxb+7qVCSxFKgxO+mAQbsNgt/5XQ==",
-      "requires": {
-        "@stimulus/core": "^1.1.1",
-        "@stimulus/webpack-helpers": "^1.1.1"
       }
     },
     "string-width": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "parser": "babel-eslint"
   },
   "dependencies": {
-    "@github/check-all": "^0.4.0",
-    "stimulus": "^1.1.1"
+    "@github/check-all": "^0.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",
@@ -48,5 +47,8 @@
     "rollup": "^2.10.9",
     "rollup-plugin-terser": "^6.1.0",
     "standard": "^16.0.1"
+  },
+  "peerDependencies": {
+    "stimulus": ">=1.1.1 <3"
   }
 }


### PR DESCRIPTION
make stimulus a peer dependency to allow usage with stimulus 2.0. see
https://discuss.hotwired.dev/t/stimulus-2-typeerror-undefined-is-not-an-object-evaluating-object-keys-valuedescriptormap/1511/2 and afcapel/stimulus-autocomplete#26.